### PR TITLE
Changed translation for single player

### DIFF
--- a/src/lang/locale/de.json
+++ b/src/lang/locale/de.json
@@ -90,7 +90,7 @@
         "total": "Total"
     },
     "DialogRoom": {
-        "singlePlayer": "Ein Spieler",
+        "singlePlayer": "Einzelspieler",
         "withFriends": "Mit Freunden",
         "invalidRoomName": "Ungültiger Name. Bitte versuche einen anderen.",
         "inProgress": "Der erste Spieler erstellt den Raum. Bitte warte und versuche es erneut.",


### PR DESCRIPTION
Single Player translated into German should be Einzelspieler.
For the German word the hyphenation would be obsolete https://www.duden.de/rechtschreibung/Einzelspieler

"Ein Spieler" was more like a word to word translation. (Translated back: One player)
Could fit too, but I am not sure if this was intended for the original "single player".