### PR TITLE
Build Docker images also for arm platforms

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -37,3 +37,4 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -37,4 +37,4 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Description
By default, docker images are only built for amd64. This is not sufficient when trying to run the Docker container on e.g. a Raspberry Pi. Right now this fails with `exec /entrypoint.sh: exec format error`


## How Has This Been Tested?
The following build succeeded and in my repository, there's the docker container for arm64 available: https://github.com/sibbl/GeoGuess/actions/runs/4157235599/jobs/7192110073

