### PR TITLE
Make getRandomLatLng() less likely to prefer higher latitudes

### DIFF
--- a/src/plugins/StreetViewService.js
+++ b/src/plugins/StreetViewService.js
@@ -148,7 +148,7 @@ class StreetViewService {
         }
 
         // Generate a random latitude and longitude
-        const lat = Math.random() * 170 - 85;
+        const lat = (Math.acos(Math.random() * 1.99 - 0.995) * 57.2958) - 90;
         const lng = Math.random() * 360 - 180;
 
         return {


### PR DESCRIPTION
<!--
Welcome and thanks!
We are glad to see that your contribution to GeoGuess.
Please note we have a [code of conduct](https://github.com/GeoGuess/Geoguess/blob/master/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
-->


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Description
<!--- Describe your changes in detail  -->
<!--- Add 'Close #<issue>', if it's link to issue -->

The current implementation of `getRandomLatLng()` assumes that the Earth is a flat rectangle and chooses a latitude and longitude uniformly, which ends up preferring higher latitudes once the rectangle is projected onto a sphere. This PR modifies the implementation to sample from the surface of the earth with equal probability (see https://math.stackexchange.com/questions/114135/how-can-i-pick-a-random-point-on-the-surface-of-a-sphere-with-equal-distribution).

I preserved the behaviour of only choosing a latitude in the range [-85, 85] (`(Math.acos(0.995) * 57.2958) - 90 == -84.3` and `(Math.acos(-0.995) * 57.2958) - 90 == 84.3`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I couldn't get Cypress working locally or on CI, but I verified that the trigonometric way of generating latitudes maintains the same bounds and played a few test games on a local deployment.

## Screenshots (if appropriate):


