### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -49,7 +49,7 @@ export async function getGeoJsonFromUrl(url) {
 
 function formatUrlGeoJSON(url){
     // if gist url get raw
-    if (/^(https?:\/\/)?gist.github.com\//.test(url)) {
+    if (/^(https?:\/\/)?gist\.github\.com\//.test(url)) {
         let urlSplit = url.split('/');
         if (
             urlSplit.length > 3 &&


### PR DESCRIPTION
Potential fix for [https://github.com/GeoGuess/GeoGuess/security/code-scanning/2](https://github.com/GeoGuess/GeoGuess/security/code-scanning/2)

To fix the issue, the `.` in the regular expression should be escaped to ensure it matches only a literal dot. This change will make the regex more precise and prevent it from matching unintended hosts. Specifically, the regex `^(https?:\/\/)?gist.github.com\/` should be updated to `^(https?:\/\/)?gist\.github\.com\/`.

The fix involves editing the regular expression on line 52 in the `formatUrlGeoJSON` function within the file `src/utils/index.js`. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
